### PR TITLE
Small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Install the latest published version:
 Or clone and build from source.  Install [rust](https://rustup.rs/), download the source, and then run:
 
 > cargo build
+
+# Usage
+
+```
+procdump [PID]
+```
+
+If the `PID` argument is missing, procdump will show information
+about its own running process.

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,7 @@ fn main() -> anyhow::Result<()> {
             _ => {}
         }
     }
+    terminal.clear()?;
 
     //println!("\n-----");
     //println!("{:?}", prc);


### PR DESCRIPTION
- clear terminal before quitting, so we don't get a cursor literally in the middle of the remaining output
- add usage section to readme

caveat: this doesn't behave like `htop` or such, the entire buffer from before procdump takes over the terminal is gone after quitting. Worth looking into.